### PR TITLE
Fix Mono version build width issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ An open-source Chinese font derived from Fontworks' Klee One. 一款开源中文
 4. 如果您使用 macOS，已经安装过 [Homebrew](https://brew.sh/)，可以在终端输入命令：`brew tap homebrew/cask-fonts && brew install font-lxgw-wenkai` 来安装本字体。
 5. 如果您使用 Windows，已经安装过 [Scoop](https://scoop.sh/)，可以在终端输入命令：`scoop bucket add nerd-fonts && scoop install LXGWWenKai` 或者 `scoop bucket add nerd-fonts && scoop install LXGWWenKaiMono` 来安装本字体。
 ### ⅱ. 从源代码生成
-请运行 `/sources/build.bat`。需要安装 [`fontmake`](https://github.com/googlefonts/fontmake)：`pip3 install fontmake`。
+请运行 `/sources/build.bat`。需要安装 [`fontmake`](https://github.com/googlefonts/fontmake)：`pip3 install fontmake` 和 [`fontTools`](https://github.com/fonttools/fonttools)：`pip3 install fonttools`。
 
 ## 注意事项
 

--- a/sources/build.bat
+++ b/sources/build.bat
@@ -14,3 +14,8 @@ For /D %%D in (.\*.ufo) do (
     echo === END ===
     echo
 )
+
+echo === Modifying MONO average width... ===
+py fix_mono.py %folder_path%
+echo === END ===
+echo

--- a/sources/fix_mono.py
+++ b/sources/fix_mono.py
@@ -1,0 +1,14 @@
+from fontTools.ttLib import TTFont
+import os, sys
+
+folder = sys.argv[1]
+
+for file in os.listdir(folder):
+    if "Mono" not in file:
+        continue
+
+    font_path = os.path.join(folder, file)
+    font = TTFont(font_path)
+    font["OS/2"].xAvgCharWidth = 500
+    font.save(font_path, reorderTables=False)
+    


### PR DESCRIPTION
Add code to automatically fix `xAvgCharWidth` to 500 for Mono fonts.