### PR TITLE
use python3 instead of python in build.sh

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -6,7 +6,7 @@ export folder_path=../fonts/TTF
 
 for f in *.ufoz; do
     echo "=== Building font ${f} ==="
-    python extract_ufoz.py ${f}
+    python3 extract_ufoz.py ${f}
 
     fontmake "${f%.*}.ufo" --keep-overlaps --keep-direction --no-generate-GDEF --no-production-names -o ttf --output-dir "${folder_path}"
     rm -rf "${f%.*}.ufo"
@@ -14,5 +14,5 @@ for f in *.ufoz; do
 done;
 
 echo "=== Modifying MONO average width... ==="
-python fix_mono.py "${folder_path}"
+python3 fix_mono.py "${folder_path}"
 echo "=== END ==="


### PR DESCRIPTION
In some Linux distribution, the python executable is not symlink to python3 by default, such as Ubuntu, openSUSE. So it is more proper to change `python` to `python3`, which is ok under these conditions.
test on Ubuntu:
```sh
$ ls -l /usr/bin/python*
lrwxrwxrwx 1 root root       9 Mar 13  2020 /usr/bin/python3 -> python3.8
-rwxr-xr-x 1 root root 5494584 Nov 14 12:59 /usr/bin/python3.8
lrwxrwxrwx 1 root root      33 Nov 14 12:59 /usr/bin/python3.8-config -> x86_64-linux-gnu-python3.8-config
lrwxrwxrwx 1 root root      16 Mar 13  2020 /usr/bin/python3-config -> python3.8-config
```

test on openSUSE:
```sh
$ ls -l /usr/bin/python*
lrwxrwxrwx 1 root root    10 Dec 13 02:15 /usr/bin/python3 -> python3.10
-rwxr-xr-x 1 root root 14448 Dec 13 02:15 /usr/bin/python3.10
-rwxr-xr-x 1 root root  3405 Dec 13 02:15 /usr/bin/python3.10-config
lrwxrwxrwx 1 root root    17 Dec 13 02:15 /usr/bin/python3-config -> python3.10-config
```